### PR TITLE
Fix tag link

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -101,7 +101,7 @@ def linkcode_resolve(domain, info):
         # return None, so [source] is not linked incorrectly
         return None
 
-    tag = "main" if "dev" in version else "v" + version
+    tag = "main" if "dev" in version else version
     return f"https://github.com/TrueLearnAI/truelearn/blob/{tag}/{filename}"
 
 


### PR DESCRIPTION
This ensures that the url points to the tag correctly, as we are no prefacing our version numbers with "v"