### PR TITLE
refactor: update how `Range` works

### DIFF
--- a/truelearn/__init__.py
+++ b/truelearn/__init__.py
@@ -6,5 +6,5 @@ Please see: https://truelearn.readthedocs.io/en/latest/ for complete documentati
 
 # Follows Semantic Versioning 2.0.0
 # https://semver.org/
-# Append '-dev' to version for development versions
+# Append '-dev' to a version for development versions
 __version__ = "1.0.0" + "-dev"

--- a/truelearn/_constraint.py
+++ b/truelearn/_constraint.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, List, Optional
+from typing import Any, Callable, Optional
 
 from truelearn.base import BaseClassifier
 from truelearn.errors import TrueLearnTypeError, TrueLearnValueError
@@ -167,16 +167,16 @@ class Range:
 
     def __init__(
         self,
-        gt: Optional[List] = None,
-        ge: Optional[List] = None,
-        le: Optional[List] = None,
-        lt: Optional[List] = None,
+        gt: Optional[float] = None,
+        ge: Optional[float] = None,
+        le: Optional[float] = None,
+        lt: Optional[float] = None,
     ):
         """Init a Range object."""
-        self.greater = gt or []
-        self.greater_or_equal = ge or []
-        self.less_or_equal = le or []
-        self.less = lt or []
+        self.greater = gt
+        self.greater_or_equal = ge
+        self.less_or_equal = le
+        self.less = lt
 
     def __repr__(self) -> str:
         """Get a description of the range object.
@@ -190,7 +190,7 @@ class Range:
             symbols,
             [self.greater_or_equal, self.greater, self.less_or_equal, self.less],
         ):
-            if not val:
+            if val is None:
                 continue
             fmt_strs.append(f"{symbol}{val}")
         return f"Range({', '.join(fmt_strs)})"
@@ -206,8 +206,8 @@ class Range:
             Whether the value is within the range.
         """
         return (
-            all(other > num for num in self.greater)
-            and all(other >= num for num in self.greater_or_equal)
-            and all(other <= num for num in self.less_or_equal)
-            and all(other < num for num in self.less)
+            (self.greater is None or other > self.greater)
+            and (self.greater_or_equal is None or other >= self.greater_or_equal)
+            and (self.less_or_equal is None or other <= self.less_or_equal)
+            and (self.less is None or other < self.less)
         )

--- a/truelearn/_constraint.py
+++ b/truelearn/_constraint.py
@@ -72,7 +72,7 @@ class ValueConstraint:
             vtype:
                 The type of the given values. Defaults to object.
                 This is typically used if the type constraint of the parameter
-                supports multuple types, and you only want to check the value
+                supports multiple types, and you only want to check the value
                 for one of the types listed in the type constraint.
         """
         self.vtype = vtype

--- a/truelearn/base.py
+++ b/truelearn/base.py
@@ -71,7 +71,7 @@ class BaseClassifier(ABC):
         Args:
             deep:
                 If True, will return the parameters for this Classifier and
-                contained sub-objects that inherits BaseClassifier class.
+                contained sub-objects that inherit BaseClassifier class.
 
         Returns:
             A dict mapping variable names to the corresponding objects.
@@ -113,9 +113,9 @@ class BaseClassifier(ABC):
 
         Raises:
             TrueLearnTypeError:
-                Types of parameters does not satisfy their constraints.
+                Types of parameters do not satisfy their constraints.
             TrueLearnValueError:
-                Values of parameters does not satisfy their constraints.
+                Values of parameters do not satisfy their constraints.
             InvalidArgumentError:
                 If the given argument name is not in the class.
         """
@@ -175,9 +175,9 @@ class BaseClassifier(ABC):
 
         Raises:
             TrueLearnTypeError:
-                Types of parameters does not satisfy their constraints.
+                Types of parameters do not satisfy their constraints.
             TrueLearnValueError:
-                Values of parameters does not satisfy their constraints.
+                Values of parameters do not satisfy their constraints.
         """
         for (
             param_name,

--- a/truelearn/datasets/_peek.py
+++ b/truelearn/datasets/_peek.py
@@ -86,7 +86,7 @@ class PEEKKnowledgeComponentGenerator(Protocol):
 
 
 def __sanity_check(train_limit: Optional[int], test_limit: Optional[int]):
-    """Check if train_limit and test_limit is valid.
+    """Check if train_limit and test_limit are valid.
 
     Args:
         train_limit:
@@ -211,7 +211,7 @@ def __restructure_data(
 
     This function extracts the time, session (learner_id),
     topics, and label from the data, and constructs the appropriate
-    the model for these data.
+    model for this data.
 
     Args:
         filepath:

--- a/truelearn/learning/_base.py
+++ b/truelearn/learning/_base.py
@@ -149,11 +149,11 @@ class InterestNoveltyKnowledgeBaseClassifier(BaseClassifier):
     _parameter_constraints: Dict[str, Any] = {
         **BaseClassifier._parameter_constraints,
         "learner_model": TypeConstraint(LearnerModel),
-        "threshold": [TypeConstraint(float), ValueConstraint(Range(ge=[0], le=[1]))],
+        "threshold": [TypeConstraint(float), ValueConstraint(Range(ge=0, le=1))],
         "init_skill": TypeConstraint(float),
         "def_var": [
             TypeConstraint(float),
-            ValueConstraint(Range(gt=[0])),
+            ValueConstraint(Range(gt=0)),
         ],
         "tau": TypeConstraint(float),
         "beta": TypeConstraint(float),
@@ -162,11 +162,11 @@ class InterestNoveltyKnowledgeBaseClassifier(BaseClassifier):
         "draw_proba_static": [
             TypeConstraint(float, type(None)),
             FuncConstraint(draw_proba_static_constraint),
-            ValueConstraint(Range(ge=[0], le=[1]), vtype=float),
+            ValueConstraint(Range(ge=0, le=1), vtype=float),
         ],
         "draw_proba_factor": [
             TypeConstraint(float),
-            ValueConstraint(Range(ge=[0])),
+            ValueConstraint(Range(ge=0)),
         ],
     }
 

--- a/truelearn/learning/_engage_classifier.py
+++ b/truelearn/learning/_engage_classifier.py
@@ -6,7 +6,7 @@ from truelearn.base import BaseClassifier
 
 
 class EngageClassifier(BaseClassifier):
-    """A Classifier that always makes positive prediction.
+    """A Classifier that always makes a positive prediction.
 
     Examples:
         >>> from truelearn.learning import EngageClassifier
@@ -14,7 +14,7 @@ class EngageClassifier(BaseClassifier):
         >>> engage = EngageClassifier()
         >>> engage
         EngageClassifier()
-        >>> # prepare event model with empty knowledge
+        >>> # prepare an event model with empty knowledge
         >>> event = EventModel()
         >>> engage.fit(event, False)
         EngageClassifier()

--- a/truelearn/learning/_ink_classifier.py
+++ b/truelearn/learning/_ink_classifier.py
@@ -18,7 +18,7 @@ class INKClassifier(BaseClassifier):
     During the training process, the meta-classifier individually trains
     the KnowledgeClassifier and the InterestClassifier. After that, the
     meta-classifier trains a set of weights by again using the ideas of team matching.
-    One team consists of the weights of the knowledge, interest and bias and
+    One team consists of the weights of the knowledge, interest and bias, and
     the other team consists of the threshold. Then, the meta-classifier
     uses the given label to adjust the weights accordingly.
 
@@ -39,7 +39,7 @@ class INKClassifier(BaseClassifier):
         >>> meta_weights = LearnerMetaWeights(novelty_weights=weights)
         >>> ink_classifier = INKClassifier(learner_meta_weights=meta_weights)
         >>>
-        >>> # prepare event model
+        >>> # prepare an event model
         >>> knowledges = [
         ...     Knowledge({1: KnowledgeComponent(mean=0.15, variance=1e-9)}),
         ...     Knowledge({
@@ -115,15 +115,15 @@ mean=0.12698..., variance=0.39796...))...}
                 The dynamic factor of learner's learning process.
                 It's used to avoid the halting of the learning process.
             greedy:
-                A bool indicating whether the meta-learning should
+                A bool indicating whether meta-learning should
                 take the greedy approach. In the greedy approach,
                 only incorrect predictions lead to the update of the weights.
 
         Raises:
             TrueLearnTypeError:
-                Types of parameters does not satisfy their constraints.
+                Types of parameters do not satisfy their constraints.
             TrueLearnValueError:
-                Values of parameters does not satisfy their constraints.
+                Values of parameters do not satisfy their constraints.
         """
         self._novelty_classifier = novelty_classifier or NoveltyClassifier()
         self._interest_classifier = interest_classifier or InterestClassifier()
@@ -219,12 +219,12 @@ mean=0.12698..., variance=0.39796...))...}
                 The predicted probability of the learner's engagement by using
                 InterestClassifier.
             pred_actual:
-                Whether the learner actually engage in the given event. This value is
+                Whether the learner actually engages in the given event. This value is
                 either 0 or 1.
         """
         cur_pred = self.predict(x)
 
-        # if prediction is correct and greedy, don't train
+        # if the prediction is correct and greedy, don't train
         if self._greedy and cur_pred == pred_actual:
             return
 
@@ -251,7 +251,7 @@ mean=0.12698..., variance=0.39796...))...}
             ),
         )
 
-        if pred_actual:  # weights need to be larger than threshold
+        if pred_actual:  # weights need to be larger than a threshold
             new_team_experts, _ = env.rate(
                 [team_experts, team_threshold],
                 weights=[(pred_novelty, pred_interest, 1), (1,)],

--- a/truelearn/learning/_interest_classifier.py
+++ b/truelearn/learning/_interest_classifier.py
@@ -26,8 +26,8 @@ class InterestClassifier(InterestNoveltyKnowledgeBaseClassifier):
 
     During the training process, the classifier uses the idea of game matching
     established in TrueSkill. It represents the learning process as a game of two teams.
-    One team consists of all the knowledge components from the learnable unit and
-    the other consist of all the corresponding knowledge components from the learner.
+    One team consists of all the knowledge components from the learnable unit, and
+    the other consists of all the corresponding knowledge components from the learner.
     Then, the classifier uses the given label to update the knowledge components of
     the learner.
 
@@ -37,7 +37,7 @@ class InterestClassifier(InterestNoveltyKnowledgeBaseClassifier):
     the learner wins the game.
 
     During the prediction process, the classifier uses cumulative density function
-    of normal distribution to calculate the probability that the learner engage in
+    of normal distribution to calculate the probability that the learner engages in
     the learning event. It calculates the probability of getting x in a
     Normal Distribution N(0, std) where x is the difference between
     the learner's skill (mean) and the learnable unit's skill (mean) and
@@ -52,7 +52,7 @@ class InterestClassifier(InterestNoveltyKnowledgeBaseClassifier):
         >>> interest_classifier = InterestClassifier()
         >>> interest_classifier
         InterestClassifier()
-        >>> # prepare event model
+        >>> # prepare an event model
         >>> knowledges = [
         ...     Knowledge({1: KnowledgeComponent(mean=0.57, variance=1e-9)}),
         ...     Knowledge({
@@ -121,11 +121,11 @@ class InterestClassifier(InterestNoveltyKnowledgeBaseClassifier):
             init_skill:
                 The initial mean of the learner's knowledge component.
                 It will be used when the learner interacts with knowledge components
-                at its first time.
+                 for its first time.
             def_var:
                 The initial variance (>0) of the learner's knowledge component.
                 It will be used when the learner interacts with knowledge components
-                at its first time.
+                 for its first time.
             beta:
                 The distance which guarantees about 76% chance of winning.
                 The recommended value is sqrt(def_var) / 2.
@@ -150,13 +150,13 @@ class InterestClassifier(InterestNoveltyKnowledgeBaseClassifier):
             decay_func_factor:
                 A factor (>=0) that will be used in both short and long
                 interest decay function. Defaults to 0, which disables
-                the interest decay function .
+                the interest decay function.
 
         Raises:
             TrueLearnTypeError:
-                Types of parameters does not satisfy their constraints.
+                Types of parameters do not satisfy their constraints.
             TrueLearnValueError:
-                Values of parameters does not satisfy their constraints.
+                Values of parameters do not satisfy their constraints.
         """
         super().__init__(
             learner_model=learner_model,
@@ -165,7 +165,7 @@ class InterestClassifier(InterestNoveltyKnowledgeBaseClassifier):
             def_var=def_var,
             tau=tau,
             beta=beta,
-            # learner always wins in interest classifier
+            # learner always wins in interest classifier,
             # hence we should always update regardless of the actual label
             # positive_only should be disabled to ensure the update method
             # is always called
@@ -219,7 +219,7 @@ class InterestClassifier(InterestNoveltyKnowledgeBaseClassifier):
             event_time:
                 An optional float representing the event time.
             _y:
-                A bool indicating whether the learner engage in
+                A bool indicating whether the learner engages in
                 the learning event.
 
         Returns:

--- a/truelearn/learning/_interest_classifier.py
+++ b/truelearn/learning/_interest_classifier.py
@@ -121,11 +121,11 @@ class InterestClassifier(InterestNoveltyKnowledgeBaseClassifier):
             init_skill:
                 The initial mean of the learner's knowledge component.
                 It will be used when the learner interacts with knowledge components
-                 for its first time.
+                for the first time.
             def_var:
                 The initial variance (>0) of the learner's knowledge component.
                 It will be used when the learner interacts with knowledge components
-                 for its first time.
+                for the first time.
             beta:
                 The distance which guarantees about 76% chance of winning.
                 The recommended value is sqrt(def_var) / 2.

--- a/truelearn/learning/_interest_classifier.py
+++ b/truelearn/learning/_interest_classifier.py
@@ -90,7 +90,7 @@ class InterestClassifier(InterestNoveltyKnowledgeBaseClassifier):
         "decay_func_type": ValueConstraint("short", "long"),
         "decay_func_factor": [
             TypeConstraint(float),
-            ValueConstraint(Range(ge=[0])),
+            ValueConstraint(Range(ge=0)),
         ],
     }
 

--- a/truelearn/learning/_knowledge_classifier.py
+++ b/truelearn/learning/_knowledge_classifier.py
@@ -16,8 +16,8 @@ class KnowledgeClassifier(InterestNoveltyKnowledgeBaseClassifier):
 
     During the training process, the classifier uses the idea of game matching
     established in TrueSkill. It represents the learning process as a game of two teams.
-    One team consists of all the knowledge components from the learnable unit and
-    the other consist of all the corresponding knowledge components from the learner.
+    One team consists of all the knowledge components from the learnable unit, and
+    the other consists of all the corresponding knowledge components from the learner.
     Then, the classifier uses the given label to update the knowledge components
     of the learner.
 
@@ -27,7 +27,7 @@ class KnowledgeClassifier(InterestNoveltyKnowledgeBaseClassifier):
     means that the learner wins the game.
 
     During the prediction process, the classifier uses cumulative density function of
-    normal distribution to calculate the probability that the learner engage
+    normal distribution to calculate the probability that the learner engages
     in the learning event. It calculates the probability of getting x in a
     Normal Distribution N(0, std) where x is the difference between
     the learner's skill (mean) and the learnable unit's skill (mean) and
@@ -42,7 +42,7 @@ class KnowledgeClassifier(InterestNoveltyKnowledgeBaseClassifier):
         >>> knowledge_classifier = KnowledgeClassifier()
         >>> knowledge_classifier
         KnowledgeClassifier()
-        >>> # prepare event model
+        >>> # prepare an event model
         >>> knowledges = [
         ...     Knowledge({1: KnowledgeComponent(mean=0.57, variance=1e-9)}),
         ...     Knowledge({
@@ -101,11 +101,11 @@ KnowledgeComponent(mean=0.60005..., variance=0.31394..., ...), ...}), ...}
             init_skill:
                 The initial mean of the learner's knowledge component.
                 It will be used when the learner interacts with knowledge components
-                at its first time.
+                for the first time.
             def_var:
                 The initial variance (>0) of the learner's knowledge component.
                 It will be used when the learner interacts with knowledge components
-                at its first time.
+                for the first time.
             beta:
                 The distance which guarantees about 76% chance of winning.
                 The recommended value is sqrt(def_var) / 2.
@@ -130,13 +130,13 @@ KnowledgeComponent(mean=0.60005..., variance=0.31394..., ...), ...}), ...}
 
         Raises:
             TrueLearnTypeError:
-                Types of parameters does not satisfy their constraints.
+                Types of parameters do not satisfy their constraints.
             TrueLearnValueError:
-                Values of parameters does not satisfy their constraints.
+                Values of parameters do not satisfy their constraints.
         """
         # the knowledge classifier doesn't rely on the draw probability
-        # it utilizes different assumptions
-        # so, we set draw probability to a very small value to avoid its impact
+        # it utilises different assumptions, so
+        # we set draw probability to a very small value to avoid its impact
         super().__init__(
             learner_model=learner_model,
             threshold=threshold,

--- a/truelearn/learning/_majority_classifier.py
+++ b/truelearn/learning/_majority_classifier.py
@@ -10,7 +10,7 @@ class MajorityClassifier(BaseClassifier):
     """A classifier that predicts based on \
     the number of learner's engagement and non-engagement.
 
-    If the number of engagement on the training data is greater than
+    If the number of engagements on the training data is greater than
     the number of non-engagement, the classifier predicts Engage (True);
     otherwise, it predicts Non-Engage (False).
 
@@ -20,7 +20,7 @@ class MajorityClassifier(BaseClassifier):
         >>> majority = MajorityClassifier()
         >>> majority
         MajorityClassifier()
-        >>> # prepare event model with empty knowledge
+        >>> # prepare an event model with empty knowledge
         >>> events = [EventModel(), EventModel(), EventModel()]
         >>> engage_stats = [False, True, True]
         >>> for event, engage_stats in zip(events, engage_stats):
@@ -46,15 +46,15 @@ class MajorityClassifier(BaseClassifier):
 
         Args:
             *: Use to reject positional arguments.
-            engagement: The number of learner's engagement.
-            non_engagement: The number of learner's non_engagement.
+            engagement: The number of learner's engagements.
+            non_engagement: The number of learner's non_engagements.
             threshold: A float that determines the classification threshold.
 
         Raises:
             TrueLearnTypeError:
-                Types of parameters does not satisfy their constraints.
+                Types of parameters do not satisfy their constraints.
             TrueLearnValueError:
-                Values of parameters does not satisfy their constraints.
+                Values of parameters do not satisfy their constraints.
         """
         super().__init__()
 

--- a/truelearn/learning/_novelty_classifier.py
+++ b/truelearn/learning/_novelty_classifier.py
@@ -96,11 +96,11 @@ KnowledgeComponent(mean=-0.36715..., variance=0.29902..., ...), ...}), ...}
             init_skill:
                 The initial mean of the learner's knowledge component.
                 It will be used when the learner interacts with knowledge components
-                 for its first time.
+                for the first time.
             def_var:
                 The initial variance (>0) of the learner's knowledge component.
                 It will be used when the learner interacts with knowledge components
-                 for its first time.
+                for the first time.
             beta:
                 The distance which guarantees about 76% chance of winning.
                 The recommended value is sqrt(def_var) / 2.

--- a/truelearn/learning/_novelty_classifier.py
+++ b/truelearn/learning/_novelty_classifier.py
@@ -15,8 +15,8 @@ class NoveltyClassifier(InterestNoveltyKnowledgeBaseClassifier):
 
     During the training process, the classifier uses the idea of game matching
     established in TrueSkill. It represents the learning process as a game of two teams.
-    One team consists of all the knowledge components from the learnable unit and
-    the other consist of all the corresponding knowledge components from the learner.
+    One team consists of all the knowledge components from the learnable unit, and
+    the other consists of all the corresponding knowledge components from the learner.
     Then, the classifier uses the given label to update the knowledge components of
     the learner.
 
@@ -37,7 +37,7 @@ class NoveltyClassifier(InterestNoveltyKnowledgeBaseClassifier):
         >>> novelty_classifier = NoveltyClassifier()
         >>> novelty_classifier
         NoveltyClassifier()
-        >>> # prepare event model
+        >>> # prepare an event model
         >>> knowledges = [
         ...     Knowledge({1: KnowledgeComponent(mean=0.57, variance=1e-9)}),
         ...     Knowledge({
@@ -96,11 +96,11 @@ KnowledgeComponent(mean=-0.36715..., variance=0.29902..., ...), ...}), ...}
             init_skill:
                 The initial mean of the learner's knowledge component.
                 It will be used when the learner interacts with knowledge components
-                at its first time.
+                 for its first time.
             def_var:
                 The initial variance (>0) of the learner's knowledge component.
                 It will be used when the learner interacts with knowledge components
-                at its first time.
+                 for its first time.
             beta:
                 The distance which guarantees about 76% chance of winning.
                 The recommended value is sqrt(def_var) / 2.
@@ -125,9 +125,9 @@ KnowledgeComponent(mean=-0.36715..., variance=0.29902..., ...), ...}), ...}
 
         Raises:
             TrueLearnTypeError:
-                Types of parameters does not satisfy their constraints.
+                Types of parameters do not satisfy their constraints.
             TrueLearnValueError:
-                Values of parameters does not satisfy their constraints.
+                Values of parameters do not satisfy their constraints.
         """
         super().__init__(
             learner_model=learner_model,
@@ -167,7 +167,7 @@ KnowledgeComponent(mean=-0.36715..., variance=0.29902..., ...), ...}), ...}
         else:  # if the person is not engaged...
             difference = sum(team_learner_mean) - sum(team_content_mean)
 
-            # check if the winner is learner or content,
+            # check if the winner is the learner or the content,
             # uses the predicted skill representation
             if difference > 0.0:  # learner wins --> boring content
                 ranks = [0, 1]

--- a/truelearn/learning/_persistent_classifier.py
+++ b/truelearn/learning/_persistent_classifier.py
@@ -16,7 +16,7 @@ class PersistentClassifier(BaseClassifier):
         >>> persistent = PersistentClassifier()
         >>> persistent
         PersistentClassifier()
-        >>> # prepare event model with empty knowledge
+        >>> # prepare an event model with empty knowledge
         >>> events = [EventModel(), EventModel(), EventModel()]
         >>> engage_stats = [False, True, False]
         >>> for event, engage_stats in zip(events, engage_stats):
@@ -41,9 +41,9 @@ class PersistentClassifier(BaseClassifier):
 
         Raises:
             TrueLearnTypeError:
-                Types of parameters does not satisfy their constraints.
+                Types of parameters do not satisfy their constraints.
             TrueLearnValueError:
-                Values of parameters does not satisfy their constraints.
+                Values of parameters do not satisfy their constraints.
         """
         super().__init__()
 

--- a/truelearn/models/_base.py
+++ b/truelearn/models/_base.py
@@ -31,8 +31,8 @@ class BaseKnowledgeComponent(Protocol):
     @property
     @abstractmethod
     def timestamp(self) -> Optional[float]:
-        """Optional[float]: The POSIX timestamp of the last update of the knowledge \
-        component."""
+        """Optional[float]: The POSIX timestamp of when the knowledge component was \
+        last updated."""
 
     @abstractmethod
     def update(

--- a/truelearn/models/_knowledge.py
+++ b/truelearn/models/_knowledge.py
@@ -49,14 +49,17 @@ description=None, url=None)
             variance:
                 A float indicating the variance of the knowledge component.
             timestamp:
-                A float indicating the POSIX timestamp of the last update of
-                the knowledge component.
+                A float
+                indicating the POSIX timestamp of when the knowledge component \
+                was last updated.
             title:
-                An optional string storing the title of the knowledge component.
+                An optional string
+                storing the title of the knowledge component.
             description:
                 An optional string that describes the knowledge component.
             url:
-                An optional string storing the url of the knowledge component.
+                An optional string
+                storing the url of the knowledge component.
 
         Returns:
             None.
@@ -111,8 +114,8 @@ description=None, url=None)
 
     @property
     def timestamp(self) -> Optional[float]:
-        """Optional[float]: The POSIX timestamp of the last update of the knowledge \
-        component."""
+        """Optional[float]: The POSIX timestamp of when the knowledge component was \
+        last updated."""
         return self.__timestamp
 
     def update(
@@ -335,7 +338,7 @@ class Knowledge:
 
     Examples:
         >>> from truelearn.models import Knowledge, KnowledgeComponent
-        >>> # construct an empty knowledge
+        >>> # construct empty knowledge
         >>> knowledge = Knowledge()
         >>> knowledge
         Knowledge(knowledge={})

--- a/truelearn/tests/test_constraints.py
+++ b/truelearn/tests/test_constraints.py
@@ -4,11 +4,11 @@ from .. import _constraint as constraint
 
 class TestRange:
     def test_repr(self):
-        r = constraint.Range(ge=[1], lt=[2])
-        assert repr(r) == "Range(>=[1], <[2])"
+        r = constraint.Range(ge=1, lt=2)
+        assert repr(r) == "Range(>=1, <2)"
 
-        r = constraint.Range(gt=[1], le=[2])
-        assert repr(r) == "Range(>[1], <=[2])"
+        r = constraint.Range(gt=1, le=2)
+        assert repr(r) == "Range(>1, <=2)"
 
-        r = constraint.Range(gt=[1], ge=[1], lt=[3], le=[2])
-        assert repr(r) == "Range(>=[1], >[1], <=[2], <[3])"
+        r = constraint.Range(gt=1, ge=1, lt=3, le=2)
+        assert repr(r) == "Range(>=1, >1, <=2, <3)"

--- a/truelearn/utils/visualisations/_bubble_plotter.py
+++ b/truelearn/utils/visualisations/_bubble_plotter.py
@@ -47,7 +47,7 @@ class BubblePlotter(MatplotlibBasePlotter):
         It will not draw anything if the knowledge given by the user is empty, or
         if topics and top_n make the filtered knowledge empty.
 
-        Currently this method requires that the mean of all knowledge components
+        Currently, this method requires that the mean of all the knowledge components
         of the learner Knowledge to be positive.
 
         Args:
@@ -74,7 +74,7 @@ class BubblePlotter(MatplotlibBasePlotter):
 
         self.ax.axis("off")
 
-        # set limit for x and y-axis
+        # set the limit for x and y-axis
         lim = max(
             max(
                 abs(circle.x) + circle.r,


### PR DESCRIPTION
### What are the changes/fixes in this PR?

In this PR, I refactored the way `Range` works. The list-based `Range` is not efficient and is very hard to use. Based on our use case in `truelearn.learning`, it makes more sense to accept only values.