### PR TITLE
Ensure LF line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,5 @@
 truelearn/tests/baseline_files/** linguist-vendored
+
+# Ensure Line endings are LF on all platforms:
+# Converts line endings to LF on checkin and prevents conversion to CRLF on checkout
+* text=auto eol=lf


### PR DESCRIPTION
<!--
Thanks for contributing a pull request to TrueLearn!

Please ensure you have taken a look at the contribution guidelines:
https://truelearn.readthedocs.io/en/latest/dev/index.html
-->

### Reference Issues/PRs

<!--
Example: Fixes #1234. See also #3456.

Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #66 

### What are the changes/fixes in this PR?

<!--
Here is an example of what you can write in this section:

1. What did you do?
2. Why? Explain the motivation.
3. The design choices you make and the reasons behind them
4. [Optional] Any new benchmarks and tests added that are worth mentioning?
-->
Update gitattributes so line endings arent converted to CLRF and are consistently LF for all platforms. This means comparison to baseline files will work correctly as line endings will be the same.