### PR TITLE
feat: allow to use dict to init INKClassifier

### DIFF
--- a/truelearn/learning/_ink_classifier.py
+++ b/truelearn/learning/_ink_classifier.py
@@ -106,9 +106,13 @@ mean=0.13029..., variance=0.39582...))...}
             learner_meta_weights:
                 The novelty/interest/bias weights.
             novelty_classifier:
-                The NoveltyClassifier.
+                The NoveltyClassifier. It can be a NoveltyClassifier object or
+                a dictionary of parameters that can be used to instantiate a
+                NoveltyClassifier object.
             interest_classifier:
-                The InterestClassifier.
+                The InterestClassifier. It can be an InterestClassifier object or
+                a dictionary of parameters that can be used to instantiate an
+                InterestClassifier object.
             threshold:
                 A float that determines the classification threshold.
             tau:

--- a/truelearn/learning/_ink_classifier.py
+++ b/truelearn/learning/_ink_classifier.py
@@ -1,5 +1,5 @@
 import math
-from typing import Any, Optional, Dict, Tuple
+from typing import Any, Optional, Dict, Tuple, Union
 from typing_extensions import Self, Final
 
 import trueskill
@@ -81,8 +81,8 @@ mean=0.13029..., variance=0.39582...))...}
     _parameter_constraints: Dict[str, Any] = {
         **BaseClassifier._parameter_constraints,
         "learner_meta_weights": TypeConstraint(LearnerMetaWeights),
-        "novelty_classifier": TypeConstraint(NoveltyClassifier),
-        "interest_classifier": TypeConstraint(InterestClassifier),
+        "novelty_classifier": TypeConstraint(NoveltyClassifier, dict),
+        "interest_classifier": TypeConstraint(InterestClassifier, dict),
         "threshold": TypeConstraint(float),
         "tau": TypeConstraint(float),
         "greedy": TypeConstraint(bool),
@@ -92,8 +92,8 @@ mean=0.13029..., variance=0.39582...))...}
         self,
         *,
         learner_meta_weights: Optional[LearnerMetaWeights] = None,
-        novelty_classifier: Optional[NoveltyClassifier] = None,
-        interest_classifier: Optional[InterestClassifier] = None,
+        novelty_classifier: Optional[Union[NoveltyClassifier, Dict]] = None,
+        interest_classifier: Optional[Union[InterestClassifier, Dict]] = None,
         threshold: float = 0.5,
         tau: float = 0.0,
         greedy: bool = False,
@@ -125,8 +125,20 @@ mean=0.13029..., variance=0.39582...))...}
             TrueLearnValueError:
                 Values of parameters do not satisfy their constraints.
         """
-        self._novelty_classifier = novelty_classifier or NoveltyClassifier()
-        self._interest_classifier = interest_classifier or InterestClassifier()
+        if novelty_classifier is None:
+            self._novelty_classifier = NoveltyClassifier()
+        elif isinstance(novelty_classifier, dict):
+            self._novelty_classifier = NoveltyClassifier(**novelty_classifier)
+        else:
+            self._novelty_classifier = novelty_classifier
+
+        if interest_classifier is None:
+            self._interest_classifier = InterestClassifier()
+        elif isinstance(interest_classifier, dict):
+            self._interest_classifier = InterestClassifier(**interest_classifier)
+        else:
+            self._interest_classifier = interest_classifier
+
         self._learner_meta_weights = learner_meta_weights or LearnerMetaWeights()
         self._threshold = threshold
         self._tau = tau

--- a/truelearn/learning/_ink_classifier.py
+++ b/truelearn/learning/_ink_classifier.py
@@ -81,8 +81,8 @@ mean=0.13029..., variance=0.39582...))...}
     _parameter_constraints: Dict[str, Any] = {
         **BaseClassifier._parameter_constraints,
         "learner_meta_weights": TypeConstraint(LearnerMetaWeights),
-        "novelty_classifier": TypeConstraint(NoveltyClassifier, dict),
-        "interest_classifier": TypeConstraint(InterestClassifier, dict),
+        "novelty_classifier": TypeConstraint(NoveltyClassifier),
+        "interest_classifier": TypeConstraint(InterestClassifier),
         "threshold": TypeConstraint(float),
         "tau": TypeConstraint(float),
         "greedy": TypeConstraint(bool),

--- a/truelearn/tests/test_learning.py
+++ b/truelearn/tests/test_learning.py
@@ -798,6 +798,25 @@ class TestINKClassifier:
 
         check_farray_close(actual_results, expected_results)
 
+    def test_ink_classifier_customize_via_dict(self, train_cases, test_events):
+        classifier = learning.INKClassifier(
+            novelty_classifier={"def_var": 0.4},
+            interest_classifier={"beta": 0.2},
+        )
+
+        train_events, train_labels = train_cases
+        for event, label in zip(train_events, train_labels):
+            classifier.fit(event, label)
+
+        expected_results = [
+            0.36741905582712336,
+            0.3247468970257655,
+            0.33375911026514554,
+        ]
+        actual_results = [classifier.predict_proba(event) for event in test_events]
+
+        check_farray_close(actual_results, expected_results)
+
     def test_ink_get_set_params(self):
         classifier = learning.INKClassifier()
 


### PR DESCRIPTION
### What are the changes/fixes in this PR?

Allow us to initialize `NoveltyClassifier` and `InterestClassifier` with `dict`. This saves the user two extra initializations and awkward syntax when they want to parameterize `NoveltyClassifier` and `InterestClassifier`.

Before:

```python
ink_classifier = INKClassifier(novelty_classifier=NoveltyClassifier(def_var=...), interest_classifier=InterestClassifier(def_var=...), ...)
```

After:

```python
ink_classifier = INKClassifier(novelty_classifier={"def_var":...}, interest_classifier={"def_var":...}, ...)
```